### PR TITLE
Improve mobile navigation and fix sidebar theme toggler overflow

### DIFF
--- a/src/components/ExpandableText.jsx
+++ b/src/components/ExpandableText.jsx
@@ -1,0 +1,43 @@
+/* eslint-disable react/prop-types */
+import { useState } from "react";
+
+const lineClampClass = {
+  2: "line-clamp-2",
+  3: "line-clamp-3",
+};
+
+const ExpandableText = ({
+  children,
+  className = "",
+  lines = 2,
+  minLength = 120,
+  buttonClassName = "",
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const text = typeof children === "string" ? children : "";
+  const canExpand = text.length > minLength;
+  const clampClass = lineClampClass[lines] || lineClampClass[2];
+
+  return (
+    <>
+      <p
+        className={`${className} ${
+          canExpand && !expanded ? `${clampClass} md:line-clamp-none` : ""
+        }`}
+      >
+        {children}
+      </p>
+      {canExpand && (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className={`mt-1 text-xs font-semibold text-primary hover:text-primary/80 md:hidden ${buttonClassName}`}
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </>
+  );
+};
+
+export default ExpandableText;

--- a/src/components/MobileCategoryPicker.jsx
+++ b/src/components/MobileCategoryPicker.jsx
@@ -1,0 +1,141 @@
+/* eslint-disable react/prop-types */
+import { useState } from "react";
+import { ChevronDown, Search, X } from "lucide-react";
+
+const MobileCategoryPicker = ({
+  label,
+  items,
+  selectedIdx,
+  open,
+  onOpenChange,
+  onSelect,
+  getMeta,
+  getSubtext,
+}) => {
+  const [query, setQuery] = useState("");
+  const selected = items[selectedIdx] || items[0];
+  const selectedMeta = selected ? getMeta(selected) : null;
+  const SelectedIcon = selectedMeta?.icon;
+  const filteredItems = items
+    .map((item, idx) => ({ item, idx, meta: getMeta(item) }))
+    .filter(({ item, meta }) => {
+      const searchText = [
+        meta.title,
+        meta.subtext,
+        getSubtext ? getSubtext(item) : "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      return searchText.includes(query.trim().toLowerCase());
+    });
+
+  return (
+    <div className="md:hidden mb-5 rounded-xl border border-base-300/50 bg-base-200/40 p-3">
+      <p className="text-xs font-semibold uppercase tracking-wider text-base-content/40">
+        {label}
+      </p>
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        className="mt-2 flex w-full items-center gap-3 rounded-lg border border-base-300/60 bg-base-100 px-3 py-2.5 text-left"
+        aria-expanded={open}
+      >
+        {SelectedIcon && (
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <SelectedIcon size={16} />
+          </span>
+        )}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-semibold">
+            {selectedMeta?.title}
+          </span>
+          {selectedMeta?.subtext && (
+            <span className="block truncate text-[11px] text-base-content/45">
+              {selectedMeta.subtext}
+            </span>
+          )}
+        </span>
+        <ChevronDown
+          size={16}
+          className={`shrink-0 text-base-content/40 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="mt-2 max-h-72 overflow-y-auto rounded-lg border border-base-300/50 bg-base-100/80 p-1">
+          <div className="sticky top-0 z-10 bg-base-100/95 p-1">
+            <div className="relative">
+              <Search
+                size={15}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base-content/35"
+              />
+              <input
+                type="text"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={`Search ${label.toLowerCase().replace("choose ", "")}...`}
+                className="input input-bordered input-sm w-full rounded-lg bg-base-200/50 pl-9 pr-8 text-xs"
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={() => setQuery("")}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-base-content/35 hover:text-base-content"
+                  aria-label="Clear search"
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+          </div>
+
+          {filteredItems.map(({ item, idx, meta }) => {
+            const Icon = meta.icon;
+            const active = idx === selectedIdx;
+            return (
+              <button
+                type="button"
+                key={meta.key}
+                onClick={() => {
+                  onSelect(idx);
+                  setQuery("");
+                }}
+                className={`flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-all ${
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-base-content/65 hover:bg-base-200"
+                }`}
+              >
+                <span
+                  className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${
+                    active ? "bg-primary/15" : "bg-base-300/60"
+                  }`}
+                >
+                  <Icon size={15} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold leading-tight">
+                    {meta.title}
+                  </span>
+                  {getSubtext && (
+                    <span className="block truncate text-[11px] text-base-content/45">
+                      {getSubtext(item)}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+
+          {filteredItems.length === 0 && (
+            <div className="px-3 py-6 text-center text-xs text-base-content/40">
+              No matches found.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MobileCategoryPicker;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,11 +1,10 @@
-import React from "react";
+/* eslint-disable react/prop-types */
 import { useNavigate, useLocation } from "react-router-dom";
 import {
     Trophy,
     ClipboardList,
     BookOpen,
     Info,
-    Home,
     ChevronLeft,
     ChevronRight,
     Send,
@@ -82,13 +81,13 @@ const Sidebar = ({ collapsed, setCollapsed }) => {
 
                 {/* Bottom section */}
                 <div className="px-3 py-4 border-t border-base-300/50 space-y-3">
-                    <div className={`flex ${collapsed ? "justify-center" : "justify-between"} items-center px-2`}>
+                    <div className={`flex ${collapsed ? "justify-center px-0" : "justify-between px-2"} items-center`}>
                         {!collapsed && (
                             <span className="text-xs text-base-content/40 uppercase tracking-wider">
                                 Theme
                             </span>
                         )}
-                        <ThemeSelector />
+                        <ThemeSelector compact={collapsed} />
                     </div>
                     <button
                         onClick={() => setCollapsed(!collapsed)}
@@ -102,7 +101,7 @@ const Sidebar = ({ collapsed, setCollapsed }) => {
 
             {/* Mobile bottom bar */}
             <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-base-200/90 backdrop-blur-xl border-t border-base-300/50 safe-area-bottom">
-                <div className="flex items-center justify-around py-2 px-2">
+                <div className="grid grid-cols-5 items-end gap-1 py-2 px-1">
                     {navItems.map((item) => {
                         const Icon = item.icon;
                         const active = isActive(item.path);
@@ -110,13 +109,15 @@ const Sidebar = ({ collapsed, setCollapsed }) => {
                             <button
                                 key={item.path}
                                 onClick={() => navigate(item.path)}
-                                className={`flex flex-col items-center gap-0.5 px-3 py-1.5 rounded-xl transition-all ${active
+                                className={`min-w-0 flex flex-col items-center gap-0.5 px-1 py-1.5 rounded-xl transition-all ${active
                                     ? "text-primary"
                                     : "text-base-content/40 hover:text-base-content/70"
                                     }`}
                             >
-                                <Icon size={20} />
-                                <span className="text-[10px] font-medium">{item.label}</span>
+                                <Icon size={20} className="shrink-0" />
+                                <span className="w-full truncate text-center text-[10px] font-medium leading-tight">
+                                    {item.label}
+                                </span>
                                 {active && (
                                     <div className="w-4 h-0.5 bg-primary rounded-full mt-0.5" />
                                 )}

--- a/src/components/ThemeSelector.jsx
+++ b/src/components/ThemeSelector.jsx
@@ -1,6 +1,7 @@
+/* eslint-disable react/prop-types */
 import React from 'react'
 
-const ThemeSelector = () => {
+const ThemeSelector = ({ compact = false }) => {
     const [theme, setTheme] = React.useState('dark');
     
     const getSystemTheme = () => {
@@ -48,7 +49,7 @@ const ThemeSelector = () => {
     }, [theme]);
 
     return (
-        <label className="flex cursor-pointer gap-1 items-center">
+        <label className={`flex cursor-pointer items-center ${compact ? "gap-0" : "gap-1"}`}>
             <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
@@ -59,15 +60,16 @@ const ThemeSelector = () => {
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="hidden sm:block">
+                className={compact ? "hidden" : "hidden sm:block"}>
                 <circle cx="12" cy="12" r="5" />
                 <path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
             </svg>
             <input 
                 type="checkbox" 
-                className="toggle toggle-sm md:toggle-md theme-controller"
+                className={`${compact ? "toggle-sm" : "toggle-sm md:toggle-md"} toggle theme-controller`}
                 onChange={toggleTheme}
                 checked={theme === 'dark'}
+                aria-label="Toggle theme"
             />
             <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -79,7 +81,7 @@ const ThemeSelector = () => {
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="hidden sm:block">
+                className={compact ? "hidden" : "hidden sm:block"}>
                 <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
             </svg>
         </label>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Search, X } from "lucide-react";
 import ThemeSelector from "./ThemeSelector";
 
-const TopBar = ({ title, subtitle, searchValue, onSearchChange, searchPlaceholder, children }) => {
+const TopBar = ({ title, subtitle, searchValue, onSearchChange, searchPlaceholder, hideMobileSearch = false, children }) => {
     return (
         <header className="sticky top-0 z-30 bg-base-100/80 backdrop-blur-xl border-b border-base-300/50">
             <div className="flex items-center justify-between min-h-[4rem] px-4 sm:px-6 lg:px-8 py-3">
@@ -51,7 +51,7 @@ const TopBar = ({ title, subtitle, searchValue, onSearchChange, searchPlaceholde
             </div>
 
             {/* Mobile search */}
-            {onSearchChange !== undefined && (
+            {onSearchChange !== undefined && !hideMobileSearch && (
                 <div className="sm:hidden px-4 pb-3">
                     <div className="relative">
                         <Search

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import adrGeneration from "../data/adrGenData.json";
 import dynamicData from "../data/dynamicGenData.json";
 import serverlessData from "../data/serverlessData.json";
@@ -9,8 +9,6 @@ import ThemeSelector from "../components/ThemeSelector";
 import { useNavigate } from "react-router-dom";
 import {
   Trophy,
-  ClipboardList,
-  BookOpen,
   ArrowRight,
   Sparkles,
   BarChart3,
@@ -230,6 +228,14 @@ const Homepage = () => {
               Explore leaderboards, compare approaches, and advance the field.
             </p>
 
+            <div className="sm:hidden mx-auto mb-5 flex w-fit max-w-[calc(100vw-2rem)] flex-wrap items-center justify-center gap-x-2 gap-y-1 rounded-full border border-base-300/60 bg-base-200/60 px-4 py-2 text-xs font-semibold text-base-content/55 animate-fade-in-up animation-delay-600">
+              <span>{totalSubmissions} submissions</span>
+              <span className="text-base-content/25">•</span>
+              <span>5 categories</span>
+              <span className="text-base-content/25">•</span>
+              <span>{new Date(latestDate).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}</span>
+            </div>
+
             {/* CTA buttons */}
             <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 px-4 animate-fade-in-up animation-delay-800">
               <button
@@ -258,7 +264,7 @@ const Homepage = () => {
             </div>
 
             {/* Stats row */}
-            <div className="flex justify-center gap-2 sm:gap-4 max-w-lg mx-auto mt-12 sm:mt-16 px-4 animate-fade-in-up animation-delay-800">
+            <div className="hidden sm:flex justify-center gap-2 sm:gap-4 max-w-lg mx-auto mt-12 sm:mt-16 px-4 animate-fade-in-up animation-delay-800">
               <div className="text-center px-2 sm:px-4 flex-shrink-0">
                 <div className="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-base-content">
                   {totalSubmissions}

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import adrGeneration from "../data/adrGenData.json";
 import serverlessData from "../data/serverlessData.json";
@@ -7,6 +7,8 @@ import traceabilityData from "../data/traceabilityData.json";
 import microserviceData from "../data/microserviceData.json";
 import { sortData, getSortIcon } from "../utils/sorting";
 import TopBar from "../components/TopBar";
+import ExpandableText from "../components/ExpandableText";
+import MobileCategoryPicker from "../components/MobileCategoryPicker";
 import {
   Layers,
   GitBranch,
@@ -38,6 +40,7 @@ const Leaderboard = () => {
   const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
   const [searchQuery, setSearchQuery] = useState("");
   const [categorySearchQuery, setCategorySearchQuery] = useState("");
+  const [mobileCategoryOpen, setMobileCategoryOpen] = useState(false);
 
   const selectedTask = taskMeta[selectedIdx].key;
   const taskData = taskMeta[selectedIdx].data;
@@ -82,6 +85,7 @@ const Leaderboard = () => {
     setSortConfig({ key: null, direction: "asc" });
     setSearchQuery("");
     setCategorySearchQuery("");
+    setMobileCategoryOpen(false);
     setMicroserviceView("incremental");
     setServerlessView("no_intervention");
     setTraceabilityView("all");
@@ -160,9 +164,7 @@ const Leaderboard = () => {
   // Check if search has no results
   const hasNoCategoryResults = searchQuery && filteredByCategory.length === 0;
 
-  // Get the filtered task index (or fall back to selected if search is empty)
-  const displayIdx = searchQuery ? (filteredByCategory.length > 0 ? taskMeta.indexOf(filteredByCategory[0]) : selectedIdx) : selectedIdx;
-  const displayTask = taskMeta[displayIdx];
+  const displayTask = taskMeta[selectedIdx];
   const displayTableData = tableData;
 
   // Filter table entries by category search query and traceability approach
@@ -192,6 +194,7 @@ const Leaderboard = () => {
         searchValue={searchQuery}
         onSearchChange={setSearchQuery}
         searchPlaceholder="Search leaderboard categories..."
+        hideMobileSearch
       >
         <button
           onClick={() => navigate("/tasks")}
@@ -209,7 +212,7 @@ const Leaderboard = () => {
             <p className="text-xs text-base-content/40 uppercase tracking-wider font-medium px-3 mb-2">
               Categories
             </p>
-            {filteredByCategory.map((meta, idx) => {
+            {filteredByCategory.map((meta) => {
               const Icon = meta.icon;
               const active = meta.key === displayTask.key;
               return (
@@ -243,37 +246,30 @@ const Leaderboard = () => {
           </div>
         </aside>
 
-        {/* Mobile category selector */}
-        <div className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-base-200/90 backdrop-blur-xl border-t border-base-300/50 px-2 py-2 flex gap-1 overflow-x-auto scrollbar-hide">
-          {taskMeta.map((meta) => {
-            const Icon = meta.icon;
-            const active = meta.key === displayTask.key;
-            return (
-              <div key={meta.key} className="tooltip tooltip-top" data-tip={meta.data.title}>
-                <button
-                  onClick={() => handleTaskChange(taskMeta.indexOf(meta))}
-                  className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs whitespace-nowrap transition-all ${active
-                      ? "bg-primary/10 text-primary font-medium"
-                      : "text-base-content/50"
-                    }`}
-                >
-                  <Icon size={14} />
-                  <span className="hidden sm:inline">{meta.data.title}</span>
-                  <span className="sm:hidden">{meta.data.title.split(" ")[0]}</span>
-                </button>
-              </div>
-            );
-          })}
-        </div>
-
         {/* Main content */}
         <div className="flex-1 p-4 sm:p-6 lg:p-8 overflow-x-auto pb-20 md:pb-8">
+          <MobileCategoryPicker
+            label="Choose Leaderboard"
+            items={taskMeta}
+            selectedIdx={selectedIdx}
+            open={mobileCategoryOpen}
+            onOpenChange={setMobileCategoryOpen}
+            onSelect={handleTaskChange}
+            getMeta={(meta) => ({
+              key: meta.key,
+              icon: meta.icon,
+              title: meta.data.title,
+              subtext: `${meta.data.entries.length} entries`,
+            })}
+            getSubtext={(meta) => `${meta.data.entries.length} entries`}
+          />
+
           {hasNoCategoryResults ? (
             <div className="flex items-center justify-center h-full min-h-[calc(100vh-8rem)]">
               <div className="text-center">
                 <p className="text-xl font-semibold text-base-content/60 mb-2">No leaderboards found</p>
                 <p className="text-sm text-base-content/40 mb-6">
-                  No leaderboard categories match "{searchQuery}". Try a different search term.
+                  No leaderboard categories match &quot;{searchQuery}&quot;. Try a different search term.
                 </p>
                 <button
                   onClick={() => setSearchQuery("")}
@@ -291,11 +287,14 @@ const Leaderboard = () => {
                 <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
                   <Medal size={22} className="text-primary" />
                 </div>
-                <div>
+                <div className="min-w-0">
                   <h2 className="text-lg font-bold">{displayTask.data.title}</h2>
-                  <p className="text-sm text-base-content/50">
+                  <ExpandableText
+                    className="text-sm text-base-content/50"
+                    minLength={110}
+                  >
                     {displayTask.data.short_description}
-                  </p>
+                  </ExpandableText>
                 </div>
               </div>
             </div>

--- a/src/pages/Papers.jsx
+++ b/src/pages/Papers.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import papersData from "../data/papersData.json";
 import TopBar from "../components/TopBar";
+import ExpandableText from "../components/ExpandableText";
 import { ExternalLink, Github, Quote } from "lucide-react";
 
 const Papers = () => {
@@ -82,9 +83,13 @@ const Papers = () => {
                 {paper.authors.join(", ")}
               </p>
 
-              <p className="text-sm text-base-content/70 leading-relaxed mb-4">
+              <ExpandableText
+                className="text-sm text-base-content/70 leading-relaxed mb-4"
+                lines={3}
+                minLength={180}
+              >
                 {paper.abstract}
-              </p>
+              </ExpandableText>
 
               <div className="flex flex-wrap gap-2">
                 {paper.arxivLink && (

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -9,6 +9,8 @@ import dynamicData from "../data/dynamicGenData.json";
 import traceabilityData from "../data/traceabilityData.json";
 import microserviceData from "../data/microserviceData.json";
 import TopBar from "../components/TopBar";
+import ExpandableText from "../components/ExpandableText";
+import MobileCategoryPicker from "../components/MobileCategoryPicker";
 import {
   Layers,
   GitBranch,
@@ -35,6 +37,7 @@ const Tasks = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [markdownContent, setMarkdownContent] = useState("");
   const [modalTitle, setModalTitle] = useState("Example");
+  const [mobileCategoryOpen, setMobileCategoryOpen] = useState(false);
 
   // Filter task categories by search
   const filteredTasks = taskMeta.filter((meta) =>
@@ -150,6 +153,7 @@ const Tasks = () => {
         searchValue={searchQuery}
         onSearchChange={setSearchQuery}
         searchPlaceholder="Search tasks by name..."
+        hideMobileSearch
       >
         <button
           onClick={() => navigate("/leaderboard")}
@@ -195,39 +199,34 @@ const Tasks = () => {
           })}
         </aside>
 
-        {/* Mobile category selector */}
-        <div className="md:hidden fixed bottom-16 left-0 right-0 z-40 bg-base-200/90 backdrop-blur-xl border-t border-base-300/50 px-2 py-2 flex gap-1 overflow-x-auto">
-          {filteredTasks.map((meta) => {
-            const Icon = meta.icon;
-            const active = meta.key === taskMeta[displayIdx].key;
-            return (
-              <div key={meta.key} className="tooltip tooltip-top" data-tip={meta.data.title}>
-                <button
-                  onClick={() => {
-                    setSelectedIdx(taskMeta.indexOf(meta));
-                    setSearchQuery("");
-                  }}
-                  className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs whitespace-nowrap transition-all ${active
-                      ? "bg-primary/10 text-primary font-medium"
-                      : "text-base-content/50"
-                    }`}
-                >
-                  <Icon size={14} />
-                  {meta.data.title.split(" ")[0]}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-
         {/* Main content */}
         <div className="flex-1 p-4 sm:p-6 lg:p-8 overflow-y-auto">
+          <MobileCategoryPicker
+            label="Choose Task"
+            items={taskMeta}
+            selectedIdx={selectedIdx}
+            open={mobileCategoryOpen}
+            onOpenChange={setMobileCategoryOpen}
+            onSelect={(idx) => {
+              setSelectedIdx(idx);
+              setSearchQuery("");
+              setMobileCategoryOpen(false);
+            }}
+            getMeta={(meta) => ({
+              key: meta.key,
+              icon: meta.icon,
+              title: meta.data.title,
+              subtext: meta.data.short_description,
+            })}
+            getSubtext={(meta) => meta.data.short_description}
+          />
+
           {hasNoResults ? (
             <div className="flex items-center justify-center h-full min-h-[calc(100vh-8rem)]">
               <div className="text-center">
                 <p className="text-xl font-semibold text-base-content/60 mb-2">No tasks found</p>
                 <p className="text-sm text-base-content/40 mb-6">
-                  No tasks match "{searchQuery}". Try a different search term.
+                  No tasks match &quot;{searchQuery}&quot;. Try a different search term.
                 </p>
                 <button
                   onClick={() => setSearchQuery("")}
@@ -247,9 +246,13 @@ const Tasks = () => {
                   <h2 className="text-2xl sm:text-3xl font-bold mb-2">
                     {task.title}
                   </h2>
-                  <p className="text-base-content/60 leading-relaxed max-w-2xl">
+                  <ExpandableText
+                    className="text-base-content/60 leading-relaxed max-w-2xl"
+                    lines={3}
+                    minLength={150}
+                  >
                     {task.long_description}
-                  </p>
+                  </ExpandableText>
                 </div>
               </div>
               <div className="flex flex-wrap gap-3 mt-6">
@@ -289,9 +292,12 @@ const Tasks = () => {
                   className="p-4 rounded-xl bg-base-200/50 border border-base-300/30 hover:border-primary/20 transition-colors"
                 >
                   <h4 className="font-bold text-sm mb-1">{metric.name}</h4>
-                  <p className="text-xs text-base-content/50 leading-relaxed">
+                  <ExpandableText
+                    className="text-xs text-base-content/50 leading-relaxed"
+                    minLength={95}
+                  >
                     {metric.description}
-                  </p>
+                  </ExpandableText>
                 </div>
               ))}
             </div>
@@ -311,9 +317,12 @@ const Tasks = () => {
                   <span className="text-xs font-semibold text-primary uppercase tracking-wider">
                     {detail.label}
                   </span>
-                  <p className="mt-1 text-sm text-base-content/70">
+                  <ExpandableText
+                    className="mt-1 text-sm text-base-content/70"
+                    minLength={95}
+                  >
                     {detail.value}
-                  </p>
+                  </ExpandableText>
                 </div>
               ))}
             </div>
@@ -338,7 +347,7 @@ const Tasks = () => {
           <div className="prose max-w-none">
             <ReactMarkdown
               components={{
-                code({ node, inline, className, children, ...props }) {
+                code({ inline, className, children, ...props }) {
                   const match = /language-(\w+)/.exec(className || "");
                   return !inline && match ? (
                     <SyntaxHighlighter


### PR DESCRIPTION
Add MobileCategoryPicker and ExpandableText components for more intuitive task/leaderboard browsing on small screens, and constrain the theme toggler so it no longer overflows the collapsed sidebar.

Fixes #7
Fixes #8